### PR TITLE
[fix] header import for RSKImageCropper to solve build error

### DIFF
--- a/ios/ImageCropPicker.h
+++ b/ios/ImageCropPicker.h
@@ -3,7 +3,7 @@
 
 #import <Foundation/Foundation.h>
 #import <QBImagePickerController/QBImagePickerController.h>
-#import <RSKImageCropper.h>
+#import <RSKImageCropper/RSKImageCropper.h>
 #import <math.h>
 #import <WeexSDK/WXModuleProtocol.h>
 #import "UIImage+Resize.h"


### PR DESCRIPTION
当主工程 podfile 中使用了 !use_framework 时，编译不通过